### PR TITLE
For now n2k doesn't know how to handle KEY_VALUE types

### DIFF
--- a/cmd/pgngen/main.go
+++ b/cmd/pgngen/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"path/filepath"
+	"slices"
 	"strconv"
 
 	//	"math"
@@ -150,6 +151,14 @@ func (conv *canboatConverter) init() {
 }
 
 func (conv *canboatConverter) fixup() {
+	// Delete PGNs that this lib doesn't know how to deal with for now.
+	conv.PGNs = slices.DeleteFunc(conv.PGNs, func(pgn PGN) (delete bool) {
+		for field := range pgn.Fields {
+			delete = pgn.Fields[field].FieldType == "KEY_VALUE"
+		}
+		return delete
+	})
+
 	conv.fixIDs()
 	conv.fixEnumDefs()
 	conv.fixRepeating()


### PR DESCRIPTION
Thank you for spending the time to put together this library! I had an issue running `make codegen`:

```
panic: template: pgninfo:117:14: executing "pgninfo" at <convertFieldType .>: error calling convertFieldType: Can't convert type: KEY_VALUE

goroutine 1 [running]:
main.(*canboatConverter).write(0xc000133ea0)
	/Users/will/www/go/src/github.com/boatkit-io/n2k/cmd/pgngen/main.go:191 +0x7b1
main.main()
	/Users/will/www/go/src/github.com/boatkit-io/n2k/cmd/pgngen/main.go:39 +0x79
exit status 2
Error: running "go run ./cmd/pgngen/main.go ./cmd/pgngen/deduper.go" failed with exit code 1
make: *** [codegen] Error 1
```

(some of those line numbers might be out compared to master). It looks to me like the lib can't handle KEY_VALUE field types right now so I added code to my fork to remove them (as I don't need them). It would be probably be useful if the lib handled KEY_VALUE types, but I don't need them so it was faster for me to skip them.