### PR TITLE
fix: Fast packet assembly

### DIFF
--- a/pkg/adapter/canadapter/multibuilder.go
+++ b/pkg/adapter/canadapter/multibuilder.go
@@ -11,7 +11,7 @@ import (
 // Instantiated by PGNBuilder
 // Uses sequence to do the work
 // we track sequences separately for each nmea source
-// sequence ids are 0-7, so each source can have 8 sequences in simultaneous transmission
+// sequence ids are 0-7, so each source|PGN can have 8 sequences in simultaneous transmission
 // sequences map[sourceid]map[pgn]map[SeqId]sequence
 type MultiBuilder struct {
 	log       *logrus.Logger

--- a/pkg/adapter/canadapter/multibuilder_test.go
+++ b/pkg/adapter/canadapter/multibuilder_test.go
@@ -134,6 +134,11 @@ func TestFastPacket(t *testing.T) {
 
 	// test misc multi frame packet out of order
 	m = NewMultiBuilder(log)
+	// zero must be first!
+	data = []uint8{0x60, 0x20, 0x00, 0x10, 0x13, 0x80, 0x0C, 0x70}
+	p = pkt.NewPacket(pInfo, data)
+	m.Add(p)
+	assert.False(t, p.Complete)
 	data = []uint8{0x63, 0x00, 0x00, 0x00, 0x00, 0x10, 0x7F, 0xFF}
 	p = pkt.NewPacket(pInfo, data)
 	m.Add(p)
@@ -143,10 +148,6 @@ func TestFastPacket(t *testing.T) {
 	m.Add(p)
 	assert.False(t, p.Complete)
 	data = []uint8{0x62, 0x55, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x7F}
-	p = pkt.NewPacket(pInfo, data)
-	m.Add(p)
-	assert.False(t, p.Complete)
-	data = []uint8{0x60, 0x20, 0x00, 0x10, 0x13, 0x80, 0x0C, 0x70}
 	p = pkt.NewPacket(pInfo, data)
 	m.Add(p)
 	assert.False(t, p.Complete)
@@ -160,6 +161,10 @@ func TestFastPacket(t *testing.T) {
 
 	// test misc multi frame packet out of order
 	m = NewMultiBuilder(log)
+	data = []uint8{0x60, 0x20, 0x00, 0x10, 0x13, 0x80, 0x0C, 0x70}
+	p = pkt.NewPacket(pInfo, data)
+	m.Add(p)
+	assert.False(t, p.Complete)
 	data = []uint8{0x63, 0x00, 0x00, 0x00, 0x00, 0x10, 0x7F, 0xFF}
 	p = pkt.NewPacket(pInfo, data)
 	m.Add(p)
@@ -169,10 +174,6 @@ func TestFastPacket(t *testing.T) {
 	m.Add(p)
 	assert.False(t, p.Complete)
 	data = []uint8{0x62, 0x55, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x7F}
-	p = pkt.NewPacket(pInfo, data)
-	m.Add(p)
-	assert.False(t, p.Complete)
-	data = []uint8{0x60, 0x20, 0x00, 0x10, 0x13, 0x80, 0x0C, 0x70}
 	p = pkt.NewPacket(pInfo, data)
 	m.Add(p)
 	assert.False(t, p.Complete)
@@ -186,6 +187,10 @@ func TestFastPacket(t *testing.T) {
 
 	// test that receiving a duplicate frame resets the sequence
 	m = NewMultiBuilder(log)
+	data = []uint8{0x60, 0x20, 0x00, 0x10, 0x13, 0x80, 0x0C, 0x70}
+	p = pkt.NewPacket(pInfo, data)
+	m.Add(p)
+	assert.False(t, p.Complete)
 	data = []uint8{0x63, 0x00, 0x00, 0x00, 0x00, 0x10, 0x7F, 0xFF}
 	p = pkt.NewPacket(pInfo, data)
 	m.Add(p)
@@ -199,10 +204,6 @@ func TestFastPacket(t *testing.T) {
 	m.Add(p)
 	// duplicate, so sequence should reset, and after "completing" the packet will remain inComplete
 	data = []uint8{0x62, 0x55, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x7F}
-	p = pkt.NewPacket(pInfo, data)
-	m.Add(p)
-	assert.False(t, p.Complete)
-	data = []uint8{0x60, 0x20, 0x00, 0x10, 0x13, 0x80, 0x0C, 0x70}
 	p = pkt.NewPacket(pInfo, data)
 	m.Add(p)
 	assert.False(t, p.Complete)


### PR DESCRIPTION
The available information is ambiguous on whether fast packet frames must arrive in order. The previous implementation allowed out of order arrival, including allowing subsequent frames to precede the first frame (which includes the length of the complete fast frame). As a result missing a frame might create a cascade of failures in receiving a fast packet from that source and pgn using the same sequence ID.

The changes tighten the ordering requirement: the first frame must precede all others. This assures that if we miss any frame in the sequence (possible since the transport does not guarantee delivery) the previous (partial) fast packet will be reset and we'll resync with the sender the next time they send a sequence for the PGN with the same sequence ID.