### PR TITLE
chore: add v0.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+
+## [0.5.0](https://github.com/boatkit-io/n2k/compare/v0.4.0..v0.5.0) - 2026-06-09
+
+### ⛰️  Features
+
+- Add managed NMEA 2000 node support - ([7342a9f](https://github.com/boatkit-io/n2k/commit/7342a9f25f5147ba591827e83b3d6623b25a1cdf)) by @inquestruss in [#69](https://github.com/boatkit-io/n2k/pull/69)
+- Add PGN discriminators and writing support - ([17a97e2](https://github.com/boatkit-io/n2k/commit/17a97e25f2250d2c6d01668ca671b86778b45593)) by @inquestruss in [#68](https://github.com/boatkit-io/n2k/pull/68)
+
+
+
+
+


### PR DESCRIPTION
Adds the generated v0.5.0 CHANGELOG.md so the existing release workflow can regenerate the same file without leaving the checkout dirty before GoReleaser runs.

This avoids changing .github/workflows/release.yaml, which requires workflow-scoped token permissions.